### PR TITLE
Sunset IRCcommands

### DIFF
--- a/sunset/code/datums/sunsetbot.dm
+++ b/sunset/code/datums/sunsetbot.dm
@@ -1,8 +1,10 @@
 /datum/world_topic/pr_announce
     keyword = "pr_announce"
+	
 /datum/world_topic/Manifest
 	keyword = "manifest"
- /datum/world_topic/manifest/Run(list/input)
+	
+/datum/world_topic/manifest/Run(list/input)
 	var/list/set_names = list(
 	"heads" = command_positions,
 	"sec" = security_positions,
@@ -31,14 +33,18 @@
 					positions["misc"] = list()
 				positions["misc"][name] = rank
  		return list2json(positions)
+
 /datum/world_topic/announce
 	keyword = "announce"
 	require_comms_key = TRUE
+
  /datum/world_topic/announce/Run(list/input)
 	for(var/client/C in clients)
 		to_chat(C, "<span class='announce'>PR: [input["msg"]]</span>")
+
 /datum/world_topic/ircrestart
 	keyword = "ircrestart"
 	require_comms_key = TRUE
+
  /datum/world_topic/ircrestart/Run(list/input)
 	return Reboot(input[keyword], input["reason"])

--- a/sunset/code/datums/sunsetbot.dm
+++ b/sunset/code/datums/sunsetbot.dm
@@ -38,7 +38,7 @@
 	keyword = "announce"
 	require_comms_key = TRUE
 
- /datum/world_topic/announce/Run(list/input)
+/datum/world_topic/announce/Run(list/input)
 	for(var/client/C in clients)
 		to_chat(C, "<span class='announce'>PR: [input["msg"]]</span>")
 

--- a/sunset/code/datums/sunsetbot.dm
+++ b/sunset/code/datums/sunsetbot.dm
@@ -1,0 +1,44 @@
+/datum/world_topic/pr_announce
+    keyword = "pr_announce"
+/datum/world_topic/Manifest
+	keyword = "manifest"
+ /datum/world_topic/manifest/Run(list/input)
+	var/list/set_names = list(
+	"heads" = command_positions,
+	"sec" = security_positions,
+	"eng" = engineering_positions,
+	"med" = medical_positions,
+	"sci" = science_positions,
+	"car" = supply_positions,
+	"srv" = service_positions,
+	"civ" = civilian_positions,
+	"bot" = nonhuman_positions
+	)
+	var/list/positions = list()
+	for(var/datum/data/record/t in data_core.general)
+			var/name = t.fields["name"]
+			var/rank = t.fields["rank"]
+			var/real_rank = t.fields["real_rank"]
+ 			var/department = 0
+			for(var/k in set_names)
+				if(real_rank in set_names[k])
+					if(!positions[k])
+						positions[k] = list()
+					positions[k][name] = rank
+					department = 1
+			if(!department)
+				if(!positions["misc"])
+					positions["misc"] = list()
+				positions["misc"][name] = rank
+ 		return list2json(positions)
+/datum/world_topic/announce
+	keyword = "announce"
+	require_comms_key = TRUE
+ /datum/world_topic/announce/Run(list/input)
+	for(var/client/C in clients)
+		to_chat(C, "<span class='announce'>PR: [input["msg"]]</span>")
+/datum/world_topic/ircrestart
+	keyword = "ircrestart"
+	require_comms_key = TRUE
+ /datum/world_topic/ircrestart/Run(list/input)
+	return Reboot(input[keyword], input["reason"])

--- a/sunsetstation.dme
+++ b/sunsetstation.dme
@@ -2734,6 +2734,7 @@
 #include "sunset\code\controllers\configuration\entries\general.dm"
 #include "sunset\code\datums\action.dm"
 #include "sunset\code\datums\shuttles.dm"
+#include "sunset\code\datums\sunsetbot.dm"
 #include "sunset\code\game\area\areas\centcom.dm"
 #include "sunset\code\game\area\areas\shuttles.dm"
 #include "sunset\code\game\gamemodes\objective.dm"


### PR DESCRIPTION
:cl: Added in some IRC Commands
add: Command to restart server
add: Command to view manifest
add: Command to announce messages
add: Command to view player notes
/:cl:

[why]: # This will allow the discord bot to do alot more, as well as reduce admin's having to hop on to restart the server.
