### PR TITLE
HEAT-LAMP SYNDROME

### DIFF
--- a/sunset/code/datums/diseases/transformation.dm
+++ b/sunset/code/datums/diseases/transformation.dm
@@ -1,0 +1,30 @@
+
+/datum/disease/transformation/lizard
+	name = "Heat-Lamp Syndrome"
+	max_stages = 5
+	cure_text = "Milk"
+	cures = list("milk")
+	agent = "lizard tears"
+	desc = "This disease turns its victim into a small lizard."
+	viable_mobtypes = list(/mob/living/carbon/human)
+	severity = DISEASE_SEVERITY_HARMFUL
+	visibility_flags = 0
+	stage1 = list("You feel dry.")
+	stage2 = list("You feel like following the janitor.")
+	stage3 = list("<span class='danger'>Your skin feels a bit... scaly.</span>")
+	stage4 = list("<span class='danger'>A juicy roach sounds delicious right about now.</span>")
+	stage5 = list("<span class='danger'>It's too cold in here!</span>", "<span class='danger'>You feel small...</span>")
+	new_form = /mob/living/simple_animal/hostile/lizard
+	var/datum/species/lizard/lizard = new /datum/species/lizard()
+
+/datum/disease/transformation/lizard/stage_act()
+	..()
+	switch(stage)
+		if(3)
+			if (prob(10))
+				affected_mob.say(pick("Hiss!"))
+		if(4)
+			affected_mob.set_species(lizard)
+		if(5)
+			if (prob(20))
+				affected_mob.say(pick("Hisss!", "Ssskree!", "HISSS!!"))

--- a/sunsetstation.dme
+++ b/sunsetstation.dme
@@ -2748,6 +2748,7 @@
 #include "sunset\code\datums\action.dm"
 #include "sunset\code\datums\shuttles.dm"
 #include "sunset\code\datums\sunsetbot.dm"
+#include "sunset\code\datums\diseases\transformation.dm"
 #include "sunset\code\game\area\Space_Station_13_areas.dm"
 #include "sunset\code\game\area\areas\centcom.dm"
 #include "sunset\code\game\area\areas\shuttles.dm"


### PR DESCRIPTION
[Changelogs]: 

:cl: battletrap360
add: Adds Heat-Lamp Syndrome, an admin-only lizard virus.

/:cl:

[why]: This was originally on Oracle, and since I coded it, I was asked to port it. It's now in the modular Sunset folder. Woo!
