### PR TITLE
Minor config edits: Blacklisting space hotel, adding constant station name

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -20,7 +20,7 @@ $include antag_rep.txt
  SERVERSQLNAME sunsetstation
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
-##STATIONNAME Space Station 13
+STATIONNAME New New Harbor Station
 
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -38,7 +38,7 @@
 #_maps/RandomRuins/SpaceRuins/onehalf.dmm
 #_maps/RandomRuins/SpaceRuins/originalcontent.dmm
 #_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
-#_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+_maps/RandomRuins/SpaceRuins/spacehotel.dmm
 #_maps/RandomRuins/SpaceRuins/thederelict.dmm
 #_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
 #_maps/RandomRuins/SpaceRuins/vaporwave.dmm


### PR DESCRIPTION
[Changelogs]: # Blacklisting space hotel, and preventing it from spawning. Adding station name, so it won't be randomized every round. Currently it's "New New Harbor Station".

:cl: config updates
config: blacklisting space hotel from spawning, adding not randomized station name
/:cl:

[why]: # I was too retarded to actually get #239 working and get rid of merge conflicts, so I disabled it instead, also added station name to have our cargo techs not scratch heads everytime they need to check shipping manifest.