### PR TITLE
no homo

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -77,7 +77,7 @@
 /obj/machinery/clonepod/examine(mob/user)
 	..()
 	if(in_range(user, src) || isobserver(user))
-		to_chat(user, "<span class='notice'>The status display reads: Speed <b>gay</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>")
+		to_chat(user, "<span class='notice'>The status display reads: Speed <b>Expected amounts</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>")
 		if(efficiency > 5)
 			to_chat(user, "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>")
 


### PR DESCRIPTION
So apparentaly this got through the checks and was on the /TG/ master branch...No fucking clue why though.

[Changelogs]: The speed on the cloning pod is no longer "Gay" now it's "Expected amounts"

:cl: mrhugo13
tweak: No longers says "Speed gay" when in range of the cloning pod.
/:cl:

[why]: Because the speed is not gay.
