### PR TITLE
Headless Changelings

### DIFF
--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -14,6 +14,7 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		var/list/missing = C.get_missing_limbs()
+		missing -= BODY_ZONE_HEAD
 		if(missing.len)
 			playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
 			C.visible_message("<span class='warning'>[user]'s missing limbs \
@@ -23,7 +24,7 @@
 				"<span class='italics'>You hear organic matter ripping \
 				and tearing!</span>")
 			C.emote("scream")
-			C.regenerate_limbs(1)
+			C.regenerate_limbs(1, list(BODY_ZONE_HEAD)) // lings will remain headless
 		if(!user.getorganslot(ORGAN_SLOT_BRAIN))
 			var/obj/item/organ/brain/B
 			if(C.has_dna() && C.dna.species.mutant_brain)


### PR DESCRIPTION
If the head is missing, then the regenerate will not be able to bring it back. This way getting your head removed as a ling will have a little bit more consequence.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Balances ling a little more so that if the head is removed, you'll still live, but now have to figure out what to do without eyes, ears, and mouth.

## Why It's Good For The Game

A little bit of balancing

## Changelog
:cl: MemeProof
tweak: regenerate now skips the head if it's missing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
